### PR TITLE
Don't multiply by number of atoms in species (again)

### DIFF
--- a/cpox.py
+++ b/cpox.py
@@ -137,20 +137,6 @@ mw = {'H': 1.008, 'O': 15.999, 'C': 12.011}
 # where the data will be stored
 integration_flux_data = defaultdict(float)
 
-def get_composition(species):
-    """
-    gets the composition of a species
-    """
-    try:
-        index = gas.species_index(species)
-        sp = gas.species(index)
-        return sp.composition
-    except:
-        index = surf.species_index(species)
-        sp = surf.species(index)
-        return sp.composition
-
-
 surf.set_multiplier(0.0)  # no surface reactions until the gauze
 for n in range(NReactors):
     # Set the state of the reservoir to match that of the previous reactor
@@ -187,11 +173,8 @@ for n in range(NReactors):
                 if net == 0.0:
                     continue
 
-                # find the count of element in the species
-                s1_composition = get_composition(s1)
-
                 # multiply by atomic mass of the element
-                net = float(fwd) * mw[element] * s1_composition[element]
+                net = float(fwd) * mw[element]
 
                 # for surface reactions, multiply by the catalyst area per volume in a reactor
                 if i == 0:


### PR DESCRIPTION
I think the element flux from Cantera already tracks the composition, i.e. in the reaction C3H8 -> C2H4 + CH4
then the 'C' flux C3H8 -> C2H4 will be 2 and the 'C' flux C3H8 -> CH4 will be 1, (and the 'H' flux will be 4 and 4 respectively), so although it makes sense to multiply by mw[element] if you want an overall mass flux once you combine them all, I don't think you want to be multiplying by s1_composition[element]. I don't think you need s1_composition at all. 

If I'm wrong, comment and close this PR